### PR TITLE
Simplify pop logic

### DIFF
--- a/stack.go
+++ b/stack.go
@@ -148,12 +148,5 @@ func (s *Stack) Pop() (interface{}, bool) {
 		// in the current one were removed.
 		s.tail = s.tail.p
 	}
-	// switch {
-	// case tp > 0:
-	// 	// There's space before tp.
-	// default:
-	// 	// Leave the slice unused as spare.
-	// 	s.tail = s.tail.p
-	// }
 	return v, true
 }

--- a/stack.go
+++ b/stack.go
@@ -143,12 +143,17 @@ func (s *Stack) Pop() (interface{}, bool) {
 	v := *vp
 	*vp = nil // Avoid memory leaks
 	s.tail.v = s.tail.v[:tp]
-	switch {
-	case tp > 0:
-		// There's space before tp.
-	default:
-		// Leave the slice unused as spare.
+	if tp <= 0 {
+		// Move to the previous slice as all elements
+		// in the current one were removed.
 		s.tail = s.tail.p
 	}
+	// switch {
+	// case tp > 0:
+	// 	// There's space before tp.
+	// default:
+	// 	// Leave the slice unused as spare.
+	// 	s.tail = s.tail.p
+	// }
 	return v, true
 }


### PR DESCRIPTION
There's a very small performance improvement, but it's measurable.

```
benchstat old.txt new.txt
name                    old time/op    new time/op    delta
Microservice/0-4          4.65ns ± 0%    4.67ns ± 1%    ~     (p=0.211 n=8+9)
Microservice/1-4           146ns ± 0%     146ns ± 1%    ~     (p=0.736 n=10+10)
Microservice/10-4          689ns ± 1%     677ns ± 0%  -1.77%  (p=0.000 n=10+10)
Microservice/100-4        5.92µs ± 0%    5.90µs ± 1%    ~     (p=0.142 n=9+9)
Microservice/1000-4       49.3µs ± 0%    49.3µs ± 1%    ~     (p=0.549 n=9+10)
Microservice/10000-4       486µs ± 0%     488µs ± 2%    ~     (p=0.356 n=9+10)
Microservice/100000-4     4.87ms ± 1%    4.83ms ± 1%  -0.73%  (p=0.009 n=10+10)
Microservice/1000000-4    49.6ms ± 1%    49.6ms ± 1%    ~     (p=0.780 n=9+10)

name                    old alloc/op   new alloc/op   delta
Microservice/0-4           0.00B          0.00B         ~     (all equal)
Microservice/1-4            112B ± 0%      112B ± 0%    ~     (all equal)
Microservice/10-4           368B ± 0%      368B ± 0%    ~     (all equal)
Microservice/100-4        5.49kB ± 0%    5.49kB ± 0%    ~     (all equal)
Microservice/1000-4       21.9kB ± 0%    21.9kB ± 0%    ~     (all equal)
Microservice/10000-4       170kB ± 0%     170kB ± 0%    ~     (all equal)
Microservice/100000-4     1.62MB ± 0%    1.62MB ± 0%    ~     (all equal)
Microservice/1000000-4    16.1MB ± 0%    16.1MB ± 0%    ~     (all equal)
```